### PR TITLE
removed ejabberd.hrl include

### DIFF
--- a/src/mod_offline_http_post.erl
+++ b/src/mod_offline_http_post.erl
@@ -7,7 +7,6 @@
 
 -export([start/2, stop/1, create_message/1, create_message/3]).
 
--include("ejabberd.hrl").
 -include("xmpp.hrl").
 -include("logger.hrl").
 


### PR DESCRIPTION
ejabberd.hrl has been removed in 18.06

tested on 19.02, but should work on 18.06+

