### PR TITLE
Confidential option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Ejabberd 17.04 module to send offline user's message via POST request to target URL.
-This module can call an api to send e.g. a push message. 
+Ejabberd 18.06+ module to send offline user's message via POST request to target URL.
+This module can call an api to send e.g. a push message.
 The request body is in application/x-www-form-urlencoded format. See the example below.
 
 V17.01
@@ -7,12 +7,14 @@ Forked from Nimrodda/mod_offline_http_post ejabberd 16.08
 
 V17.04 updated and tested in 17.04, I assume it works in 17.03 also.
 
+V19.02 updated and tested in 19.02, I assume it works in 18.06, 18.09 and 18.12 also.
+
 Installation
 ------------
 
-1. cd /opt/ejabberd-17.04/.ejabberd-module/sources/
+1. cd /opt/ejabberd-19.02/.ejabberd-module/sources/
 2. git clone https://github.com/PH-F/mod_offline_http_post.git;
-3. bash /opt/ejabberd-17.04/.ejabberd-module/bin/ejabberdctl module-install mod_offline_http_post
+3. bash /opt/ejabberd-19.02/.ejabberd-module/bin/ejabberdctl module-install mod_offline_http_post
 4. /etc/init.d/ejabberd restart;
 
 That's it. The module is now installed.
@@ -26,10 +28,12 @@ Add the following to ejabberd configuration under `modules:`
 mod_offline_http_post:
     auth_token: "secret"
     post_url: "http://example.com/notify"
+    confidential: true
 ```
 
 -    auth_token - user defined, hard coded token that will be sent as part of the request's body. Use this token on the target server to validate that the request arrived from a trusted source.
 -    post_url - the server's endpoint url
+-    confidential - boolean parameter; if true, do not send the message body in post data. if false (default), send the message body.
 
 Example of the outgoing request:
 --------------------------------

--- a/src/mod_offline_http_post.erl
+++ b/src/mod_offline_http_post.erl
@@ -41,7 +41,7 @@ post_offline_message(From, To, Body, MessageId) ->
   ToUser = To#jid.luser,
   FromUser = From#jid.luser,
   Vhost = To#jid.lserver,
-  case gen_mod:get_module_opt(To#jid.lserver, ?MODULE, confidential) of
+  case gen_mod:get_module_opt(To#jid.lserver, ?MODULE, confidential, false) of
     true -> Data = string:join(["to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&messageId=", binary_to_list(MessageId)], "");
     false -> Data = string:join(["to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&body=", binary_to_list(Body), "&messageId=", binary_to_list(MessageId)], "")
   end,

--- a/src/mod_offline_http_post.erl
+++ b/src/mod_offline_http_post.erl
@@ -41,7 +41,10 @@ post_offline_message(From, To, Body, MessageId) ->
   ToUser = To#jid.luser,
   FromUser = From#jid.luser,
   Vhost = To#jid.lserver,
-  Data = string:join(["to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&body=", binary_to_list(Body), "&messageId=", binary_to_list(MessageId)], ""),
+  case gen_mod:get_module_opt(To#jid.lserver, ?MODULE, confidential) of
+    true -> Data = string:join(["to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&messageId=", binary_to_list(MessageId)], "");
+    false -> Data = string:join(["to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&body=", binary_to_list(Body), "&messageId=", binary_to_list(MessageId)], "");
+  end,
   Request = {binary_to_list(PostUrl), [{"Authorization", binary_to_list(Token)}], "application/x-www-form-urlencoded", Data},
   httpc:request(post, Request,[],[]),
   ?INFO_MSG("post request sent", []).

--- a/src/mod_offline_http_post.erl
+++ b/src/mod_offline_http_post.erl
@@ -41,7 +41,7 @@ post_offline_message(From, To, Body, MessageId) ->
   ToUser = To#jid.luser,
   FromUser = From#jid.luser,
   Vhost = To#jid.lserver,
-  case (gen_mod:get_module_opt(To#jid.lserver, ?MODULE, confidential) of
+  case gen_mod:get_module_opt(To#jid.lserver, ?MODULE, confidential of
     true -> Data = string:join(["to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&messageId=", binary_to_list(MessageId)], "");
     false -> Data = string:join(["to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&body=", binary_to_list(Body), "&messageId=", binary_to_list(MessageId)], "")
   end,

--- a/src/mod_offline_http_post.erl
+++ b/src/mod_offline_http_post.erl
@@ -41,7 +41,7 @@ post_offline_message(From, To, Body, MessageId) ->
   ToUser = To#jid.luser,
   FromUser = From#jid.luser,
   Vhost = To#jid.lserver,
-  if (gen_mod:get_module_opt(To#jid.lserver, ?MODULE, confidential) of
+  case (gen_mod:get_module_opt(To#jid.lserver, ?MODULE, confidential) of
     true -> Data = string:join(["to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&messageId=", binary_to_list(MessageId)], "");
     false -> Data = string:join(["to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&body=", binary_to_list(Body), "&messageId=", binary_to_list(MessageId)], "")
   end,

--- a/src/mod_offline_http_post.erl
+++ b/src/mod_offline_http_post.erl
@@ -41,7 +41,7 @@ post_offline_message(From, To, Body, MessageId) ->
   ToUser = To#jid.luser,
   FromUser = From#jid.luser,
   Vhost = To#jid.lserver,
-  case gen_mod:get_module_opt(To#jid.lserver, ?MODULE, confidential of
+  case gen_mod:get_module_opt(To#jid.lserver, ?MODULE, confidential) of
     true -> Data = string:join(["to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&messageId=", binary_to_list(MessageId)], "");
     false -> Data = string:join(["to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&body=", binary_to_list(Body), "&messageId=", binary_to_list(MessageId)], "")
   end,

--- a/src/mod_offline_http_post.erl
+++ b/src/mod_offline_http_post.erl
@@ -41,9 +41,9 @@ post_offline_message(From, To, Body, MessageId) ->
   ToUser = To#jid.luser,
   FromUser = From#jid.luser,
   Vhost = To#jid.lserver,
-  case gen_mod:get_module_opt(To#jid.lserver, ?MODULE, confidential) of
+  if (gen_mod:get_module_opt(To#jid.lserver, ?MODULE, confidential) of
     true -> Data = string:join(["to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&messageId=", binary_to_list(MessageId)], "");
-    false -> Data = string:join(["to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&body=", binary_to_list(Body), "&messageId=", binary_to_list(MessageId)], "");
+    false -> Data = string:join(["to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&body=", binary_to_list(Body), "&messageId=", binary_to_list(MessageId)], "")
   end,
   Request = {binary_to_list(PostUrl), [{"Authorization", binary_to_list(Token)}], "application/x-www-form-urlencoded", Data},
   httpc:request(post, Request,[],[]),


### PR DESCRIPTION
added a new option 'confidential'.
It true, do not send the message body in the post data. This is often sufficient for notification services for example.
Also updated documentation.